### PR TITLE
Extend syntax, support property addition/removal

### DIFF
--- a/Cds.IO.Soundings/AppFile{T}.cs
+++ b/Cds.IO.Soundings/AppFile{T}.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cds.IO
+{
+    public abstract class AppFile<T> : CdsFile<T>
+        where T : AppFile<T>, new()
+    {
+        [Field] public string Type { get; set; }
+        [Field] public Version Version { get; set; }
+        [Field(Format = "yyyy-MM-dd HH:mm:ss")] public DateTime Created { get; set; }
+        [Field] public string FilePath { get; set; }
+        [Section] public SourceApplication Application { get; set; }
+    }
+}

--- a/Cds.IO.Soundings/Cds.IO.Soundings.csproj
+++ b/Cds.IO.Soundings/Cds.IO.Soundings.csproj
@@ -4,16 +4,15 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{A1B95584-DF2F-4EA9-8C36-4336B9F95148}</ProjectGuid>
-    <OutputType>Exe</OutputType>
-    <RootNamespace>Demo</RootNamespace>
-    <AssemblyName>Demo</AssemblyName>
+    <ProjectGuid>{E525689D-68FB-45AE-9F61-B4D29DA5603A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Cds.IO</RootNamespace>
+    <AssemblyName>Cds.IO.Soundings</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -23,7 +22,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -42,21 +40,15 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Program.cs" />
+    <Compile Include="AppFile{T}.cs" />
+    <Compile Include="CoordinateData.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SoundingCoordinates.cs" />
+    <Compile Include="SoundingFile{T}.cs" />
+    <Compile Include="SoundingInfo.cs" />
+    <Compile Include="SourceApplication.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Cds.IO.Soundings\Cds.IO.Soundings.csproj">
-      <Project>{e525689d-68fb-45ae-9f61-b4d29da5603a}</Project>
-      <Name>Cds.IO.Soundings</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Cds.IO.Vane\Cds.IO.Vane.csproj">
-      <Project>{a4e2aa03-6d35-44e0-b877-7912e0b36fb7}</Project>
-      <Name>Cds.IO.Vane</Name>
-    </ProjectReference>
     <ProjectReference Include="..\Cds.IO\Cds.IO.csproj">
       <Project>{0fa225b0-00c5-4740-bc1c-c7c11b627ae3}</Project>
       <Name>Cds.IO</Name>

--- a/Cds.IO.Soundings/CoordinateData.cs
+++ b/Cds.IO.Soundings/CoordinateData.cs
@@ -1,0 +1,14 @@
+﻿namespace Cds.IO
+{
+    public class CoordinateData
+    {
+        [Field] public double? Northing { get; set; }
+        [Field] public double? Easting { get; set; }
+        [Field] public double? Latitude { get; set; }
+        [Field] public double? Longitude { get; set; }
+        [Field("Surface Elevation")] public double? SurfaceElevation { get; set; }
+
+        [Field("GPGGA")] public string Gpgga { get; set; }
+        [Field("GPRMC")] public string Gprmc { get; set; }
+    }
+}

--- a/Cds.IO.Soundings/Properties/AssemblyInfo.cs
+++ b/Cds.IO.Soundings/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Cds.IO.Soundings")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Cds.IO.Soundings")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e525689d-68fb-45ae-9f61-b4d29da5603a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Cds.IO.Soundings/SoundingCoordinates.cs
+++ b/Cds.IO.Soundings/SoundingCoordinates.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+
+namespace Cds.IO
+{
+    public class SoundingCoordinates
+    {
+        [Field("Coordinate Source")] public string CoordinateSource { get; set; }
+        [Field("Coordinate System")] public string CoordinateSystem { get; set; }
+        [Field("Coordinate Datum")] public string CoordinateDatum { get; set; }
+        [Field("Coordinate Type")] public string CoordinateType { get; set; }
+        [Field("Coordinate Units")] public string CoordinateUnits { get; set; }
+        [Field("EPSG ID")] public int EpsgID { get; set; }
+        [Field("UTM Zone Text")] public string UtmZoneText { get; set; }
+        [Field("UTM Zone Number")] public int UtmZoneNumber { get; set; }
+        [Field("Elevation Source")] public string ElevationSource { get; set; }
+        [Field("Elevation Units")] public string ElevationUnits { get; set; }
+        [Field("Elevation Reference")] public string ElevationReference { get; set; }
+        [Text] public string Comment { get; set; }
+        [Table] public IList<CoordinateData> Data { get; set; }
+    }
+}

--- a/Cds.IO.Soundings/SoundingFile{T}.cs
+++ b/Cds.IO.Soundings/SoundingFile{T}.cs
@@ -1,0 +1,13 @@
+﻿using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cds.IO
+{
+    public abstract class SoundingFile<T> : AppFile<T>
+        where T : SoundingFile<T>, new()
+    {
+        [Section] public SoundingInfo Sounding { get; set; }
+        [Section] public SoundingCoordinates Coordinates { get; set; }
+    }
+}

--- a/Cds.IO.Soundings/SoundingInfo.cs
+++ b/Cds.IO.Soundings/SoundingInfo.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Cds.IO
+{
+    public class SoundingInfo
+    {
+        [Field("Job Number")] public string JobNumber { get; set; }
+        [Field] public string Client { get; set; }
+        [Field] public string Project { get; set; }
+        [Field] public string Location { get; set; }
+        [Field("Sounding ID")] public string SoundingID { get; set; }
+        [Field] public string Crew { get; set; }
+        [Field("Base Filename")] public string BaseFilename { get; set; }
+        [Field(Format = "yyyy-MM-dd HH:mm:ss")] public DateTime Started { get; set; }
+
+    }
+}

--- a/Cds.IO.Soundings/SourceApplication.cs
+++ b/Cds.IO.Soundings/SourceApplication.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Cds.IO
+{
+    public class SourceApplication
+    {
+        [Field] public string Name { get; set; }
+        [Field] public Version Version { get; set; }
+    }
+}

--- a/Cds.IO.Tests/Cds.IO.Tests.csproj
+++ b/Cds.IO.Tests/Cds.IO.Tests.csproj
@@ -55,6 +55,14 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Cds.IO.Soundings\Cds.IO.Soundings.csproj">
+      <Project>{e525689d-68fb-45ae-9f61-b4d29da5603a}</Project>
+      <Name>Cds.IO.Soundings</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Cds.IO.Vane\Cds.IO.Vane.csproj">
+      <Project>{a4e2aa03-6d35-44e0-b877-7912e0b36fb7}</Project>
+      <Name>Cds.IO.Vane</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Cds.IO\Cds.IO.csproj">
       <Project>{0fa225b0-00c5-4740-bc1c-c7c11b627ae3}</Project>
       <Name>Cds.IO</Name>

--- a/Cds.IO.Vane/Cds.IO.Vane.csproj
+++ b/Cds.IO.Vane/Cds.IO.Vane.csproj
@@ -4,16 +4,15 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{A1B95584-DF2F-4EA9-8C36-4336B9F95148}</ProjectGuid>
-    <OutputType>Exe</OutputType>
-    <RootNamespace>Demo</RootNamespace>
-    <AssemblyName>Demo</AssemblyName>
+    <ProjectGuid>{A4E2AA03-6D35-44E0-B877-7912E0B36FB7}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Cds.IO</RootNamespace>
+    <AssemblyName>Cds.IO.Vane</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -23,7 +22,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -42,20 +40,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Program.cs" />
+    <Compile Include="VaneFile.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cds.IO.Soundings\Cds.IO.Soundings.csproj">
       <Project>{e525689d-68fb-45ae-9f61-b4d29da5603a}</Project>
       <Name>Cds.IO.Soundings</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Cds.IO.Vane\Cds.IO.Vane.csproj">
-      <Project>{a4e2aa03-6d35-44e0-b877-7912e0b36fb7}</Project>
-      <Name>Cds.IO.Vane</Name>
     </ProjectReference>
     <ProjectReference Include="..\Cds.IO\Cds.IO.csproj">
       <Project>{0fa225b0-00c5-4740-bc1c-c7c11b627ae3}</Project>

--- a/Cds.IO.Vane/Properties/AssemblyInfo.cs
+++ b/Cds.IO.Vane/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Cds.IO.Vane")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Cds.IO.Vane")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a4e2aa03-6d35-44e0-b877-7912e0b36fb7")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Cds.IO.Vane/VaneFile.cs
+++ b/Cds.IO.Vane/VaneFile.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cds.IO
+{
+    public class VaneFile : SoundingFile<VaneFile>
+    {
+
+    }
+}

--- a/Cds.IO/Cds.IO.csproj
+++ b/Cds.IO/Cds.IO.csproj
@@ -40,18 +40,26 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Converters\DefaultConverter.cs" />
+    <Compile Include="Converters\FieldConverter.cs" />
+    <Compile Include="Converters\VersionConverter.cs" />
     <Compile Include="Formats\Binary\BinaryFileReader.cs" />
     <Compile Include="Formats\Binary\BinaryFileWriter.cs" />
     <Compile Include="CdsFile{T}.cs" />
     <Compile Include="FieldAttribute.cs" />
+    <Compile Include="Formats\Text\RowParser.cs" />
+    <Compile Include="Formats\Text\TextFingerprint.cs" />
+    <Compile Include="Formats\Text\TextScanner.cs" />
     <Compile Include="Schema\FileField.cs" />
     <Compile Include="Schema\FileSchema.cs" />
     <Compile Include="Schema\FileSection.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Schema\InheritanceLevel.cs" />
     <Compile Include="TableAttribute.cs" />
     <Compile Include="SectionAttribute.cs" />
     <Compile Include="Formats\Text\TextFileReader.cs" />
     <Compile Include="Formats\Text\TextFileWriter.cs" />
+    <Compile Include="TextAttribute.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Cds.IO/Converters/DefaultConverter.cs
+++ b/Cds.IO/Converters/DefaultConverter.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Cds.IO.Converters
+{
+    class DefaultConverter : FieldConverter
+    {
+        protected override object ConvertCore(Type type, object value)
+        {            
+            var converter = TypeDescriptor.GetConverter(type);
+            return converter.CanConvertFrom(value?.GetType() ?? typeof(object))
+                ? converter.ConvertFrom(value)
+                : null;            
+        }
+    }
+}

--- a/Cds.IO/Converters/FieldConverter.cs
+++ b/Cds.IO/Converters/FieldConverter.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cds.IO.Converters
+{
+    public abstract class FieldConverter
+    {
+        static object Sync { get; } = new object();
+        static IEnumerable<FieldConverter> Converters { get; set; } = new FieldConverter[]
+        {
+            new DefaultConverter(), new VersionConverter()
+        };
+
+        public static void Register(FieldConverter converter)
+        {
+            lock (Sync)
+                Converters = new List<FieldConverter>(Converters) { converter };
+        }
+
+        public static object Convert(Type type, object value) =>
+            Converters
+                .Select(c => c.ConvertCore(type, value))
+                .FirstOrDefault(v => v != null);
+
+        protected abstract object ConvertCore(Type type, object value);
+    }
+}

--- a/Cds.IO/Converters/VersionConverter.cs
+++ b/Cds.IO/Converters/VersionConverter.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Cds.IO.Converters
+{
+    class VersionConverter : FieldConverter
+    {
+        protected override object ConvertCore(Type type, object value) =>
+            type == typeof(Version) && value != null
+            ? Version.Parse(value.ToString())
+            : null;
+    }
+}

--- a/Cds.IO/Formats/Text/RowParser.cs
+++ b/Cds.IO/Formats/Text/RowParser.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cds.IO.Formats.Text
+{
+    static class RowParser
+    {
+        public static string[] ParseRow(this string line)
+        {
+            using (var reader = new StringReader(line))
+                return reader.ReadRow().ToArray();
+        }
+
+        static IEnumerable<string> ReadRow(this TextReader reader)
+        {
+            while (reader.TryReadValue(out var value))
+                yield return value;
+        }
+
+        static bool TryReadValue(this TextReader reader, out string value)
+        {
+            reader.SkipWhiteSpaces();
+            return reader.Quote()
+                ? reader.TryReadQuotedValue(out value)
+                : reader.TryReadUnquotedValue(out value);
+        }
+
+        static bool TryReadQuotedValue(this TextReader reader, out string value)
+        {
+            value = null;
+            if (reader.Read() != '"')
+                return false;
+
+            var sb = new StringBuilder();
+            while(true)
+                switch (reader.Read())
+                {
+                    case -1:
+                        return false;
+
+                    case int c when c == '"':
+                        if (reader.Quote())
+                        {
+                            sb.Append((char)reader.Read());
+                            break;
+                        }
+                        else
+                        {
+                            value = sb.ToString();
+                            return true;
+                        }
+
+                    case int c:
+                        sb.Append((char)c);
+                        break;
+                }
+        }
+
+        static bool TryReadUnquotedValue(this TextReader reader, out string value)
+        {
+            value = null;
+            if (!reader.Content())
+                return false;
+
+            var sb = new StringBuilder();
+            while (reader.Content())
+                sb.Append((char)reader.Read());
+
+            value = sb.ToString();
+            if (value == "N/A")
+                value = null;
+
+            return true;
+        }
+
+        static void SkipWhiteSpaces(this TextReader reader)
+        {
+            while (reader.WhiteSpace())
+                reader.Read();
+        }
+
+        static bool Content(this TextReader reader) =>
+            !reader.EndOfFile() && !reader.WhiteSpace(); 
+
+        static bool EndOfFile(this TextReader reader) =>
+            reader.Peek() == -1;
+
+        static bool Quote(this TextReader reader) =>
+            (char)reader.Peek() == '"';
+
+        static bool WhiteSpace(this TextReader reader) =>
+            char.IsWhiteSpace((char)reader.Peek());
+    }
+}

--- a/Cds.IO/Formats/Text/TextFingerprint.cs
+++ b/Cds.IO/Formats/Text/TextFingerprint.cs
@@ -1,0 +1,11 @@
+﻿namespace Cds.IO.Formats.Text
+{
+    static class TextFingerprint
+    {
+        public static string Unify(this string text) => text
+            .Replace(" ", "")
+            .Replace("\t", "")
+            .Trim()
+            .ToLower();
+    }
+}

--- a/Cds.IO/Formats/Text/TextScanner.cs
+++ b/Cds.IO/Formats/Text/TextScanner.cs
@@ -1,0 +1,135 @@
+﻿using Cds.IO.Schema;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static System.String;
+
+namespace Cds.IO.Formats.Text
+{
+    class TextScanner : IDisposable
+    {
+        public TextScanner(TextReader reader)
+        {
+            Reader = reader ?? throw new ArgumentNullException(nameof(reader));
+            Read();            
+        }
+
+        TextReader Reader { get; }
+        string Line { get; set; }
+
+        public void Dispose() =>
+            Reader.Dispose();
+
+        public bool Read()
+        {
+            Line = Reader.ReadLine();
+            return !EndOfFile;
+        }
+
+        public bool EndOfFile => Line == null;
+
+        public bool Content =>
+            !EndOfFile &&
+            !WhiteSpace &&
+            !StartOfSection &&
+            !EndOfSection;
+
+        public bool WhiteSpace => 
+            !EndOfFile && 
+            IsNullOrWhiteSpace(Line);
+
+        public bool StartOfSection =>
+            !EndOfFile &&
+            Line.StartsWith("<<<");
+
+        public bool EndOfSection =>
+            !EndOfFile &&
+            Line.StartsWith(">>>");
+
+        public void SkipWhiteSpace()
+        {
+            while (WhiteSpace)
+                Read();
+        }
+
+        public bool TryGetSectionStart(FileSection section) =>
+            StartOfSection &&
+            Line.StartsWith(new string('<', section.Level)) &&
+            Line.Unify().Contains(section.Name.Unify());
+
+        public bool TryGetSectionEnd(FileSection section) =>
+            EndOfSection && 
+            Line.TrimEnd() == new string('>', section.Level);
+
+        public bool TrySkipSectionEnd(FileSection section)
+        {
+            while (!TryGetSectionEnd(section))
+                if (!Read())
+                    return false;
+
+            Read();
+            return true;
+        }
+
+        public bool TryGetProperty(FileField field, out string value)
+        {
+            value = null;
+            if (!Content)
+                return false;
+
+            var split = Line.IndexOf(':');
+            if (split == -1)
+                return false;
+
+            var name = Line.Substring(0, split);
+            if (name.Unify() != field.Name.Unify())
+                return false;
+
+            value = Line.Substring(split + 1).Trim();
+            return true;
+        }
+
+        public bool TryGetColumns(FileSection section)
+        {
+            if (!Content)
+                return false;
+
+            return Enumerable.SequenceEqual(
+                from f in section.Schema.Fields
+                select f.Name.Unify(),
+                from c in Line.Split(',')
+                select c.Unify());
+        }
+
+        public bool TryGetRows(FileSection section, out string[] values)
+        {
+            values = new string[0];
+            if (!Content)
+                return false;
+
+            values = Line.ParseRow();
+            return section.Schema.Fields.Count <= values.Length;
+        }
+
+        public bool TryGetText(out string text)
+        {
+            text = null;
+            if (EndOfFile || StartOfSection)
+                return false;
+
+            var sb = new StringBuilder();
+            while (Content || WhiteSpace)
+            {
+                sb.AppendLine(Line);
+                if (!Read())
+                    return false;
+            }
+
+            text = sb.ToString().Trim();
+            return true;
+        }
+    }
+}

--- a/Cds.IO/Schema/FileField.cs
+++ b/Cds.IO/Schema/FileField.cs
@@ -14,7 +14,7 @@ namespace Cds.IO.Schema
             from property in type.GetProperties()
             let attribute = property.GetCustomAttribute<FieldAttribute>()
             where attribute != null
-            orderby attribute.Order
+            orderby property.DeclaringType.GetLevel(), attribute.Order
             select new FileField(property, attribute);
 
         FileField(PropertyInfo property, FieldAttribute attribute)
@@ -28,6 +28,7 @@ namespace Cds.IO.Schema
 
         public string Name => Attribute.Name;
         public Type Type => Property.PropertyType;
+        public bool Text => Type == typeof(string);
 
         public object this[object target]
         {
@@ -36,7 +37,9 @@ namespace Cds.IO.Schema
         }
 
         public string Format(object target) =>
-            string.Format("{0" + 
+            this[target] == null 
+            ? null
+            : string.Format("{0" + 
                 (Attribute.Width == 0 ? "": "," + Attribute.Width) +
                 (Attribute.Format == "" ? "" : ":" + Attribute.Format) +
                 "}", this[target]);

--- a/Cds.IO/Schema/InheritanceLevel.cs
+++ b/Cds.IO/Schema/InheritanceLevel.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Cds.IO.Schema
+{
+    static class InheritanceLevel
+    {
+        public static int GetLevel(this Type type, int level = 1) =>
+            type.BaseType == typeof(object) ? level : type.BaseType.GetLevel(level + 1);
+    }
+}

--- a/Cds.IO/TextAttribute.cs
+++ b/Cds.IO/TextAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace Cds.IO
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class TextAttribute : SectionAttribute
+    {
+        public TextAttribute([CallerMemberName] string name = null, [CallerLineNumber] int order = 0)
+            : base(name, order)
+        {
+        }
+    }
+}

--- a/Demo/Program.cs
+++ b/Demo/Program.cs
@@ -12,7 +12,73 @@ namespace Demo
     {
         static void Main(string[] args)
         {
-            
+            var file = Sample();
+            var copy = VaneFile.Parse(file.ToString());
+
+            if (file.ToString() != copy.ToString())
+                WriteLine("Oops!");
+            else
+                WriteLine(copy);
+        }
+
+
+        static VaneFile Sample()
+        {
+            return new VaneFile
+            {
+                Type = "Vane Test",
+                Version = new Version(0, 1),
+                Created = DateTime.Now,
+                FilePath = "D:\\17-04073_VST443.vstx",
+                Application = new SourceApplication
+                {
+                    Name = "eVane",
+                    Version = new Version(0, 1),
+                },
+
+                Sounding = new SoundingInfo
+                {
+                    JobNumber = "17-04073",
+                    Client = "Suncor",
+                    Project = "2017 STP Foundation Investigation",
+                    Location = "STP",
+                    SoundingID = "VST17-STP-G-443",
+                    Crew = "BKIR/QROB",
+                    BaseFilename = "17-04073_VST443",
+                    Started = DateTime.Now,
+                },
+
+                Coordinates = new SoundingCoordinates
+                {
+                    CoordinateSource = "ConeTec Trimble Survey (RTK)",
+                    CoordinateSystem = "Suncor Steepbank",
+                    CoordinateDatum = "Suncor Local",
+                    CoordinateType = "Local Grid",
+                    CoordinateUnits = "Metre",
+                    EpsgID = 9100003,
+                    UtmZoneText = "N/A",
+                    UtmZoneNumber = 0,
+                    ElevationSource = "ConeTec Trimble Survey (RTK)",
+                    ElevationUnits = "Metre",
+                    ElevationReference = "Suncor Steepbank (site specific adjustment)",
+                    Comment = "N/A",
+                    Data = new[]
+                                {
+                        new CoordinateData
+                        {
+                            Northing = 240245.319,
+                            Easting = 151599.147,
+                            Latitude = null,
+                            Longitude = null,
+                            SurfaceElevation = 376.934,
+                            Gpgga = "$GPGGA,172640.000,4911.7306,N,12305.4756,W,1,07,1.2,18.0,M,-16.8,M,,0000*5D",
+                            Gprmc = "$GPRMC,172640.000,A,4911.7306,N,12305.4756,W,0.00,151.30,200715,,,A*77",
+                        }
+                    }
+                },
+            };
         }
     }
+
+
 }

--- a/cdsio.sln
+++ b/cdsio.sln
@@ -9,6 +9,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cds.IO.Tests", "Cds.IO.Test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Demo", "Demo\Demo.csproj", "{A1B95584-DF2F-4EA9-8C36-4336B9F95148}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cds.IO.Soundings", "Cds.IO.Soundings\Cds.IO.Soundings.csproj", "{E525689D-68FB-45AE-9F61-B4D29DA5603A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cds.IO.Vane", "Cds.IO.Vane\Cds.IO.Vane.csproj", "{A4E2AA03-6D35-44E0-B877-7912E0B36FB7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{AA4021A7-A2E1-46CD-AE9C-D9D5D66C38B2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,9 +33,21 @@ Global
 		{A1B95584-DF2F-4EA9-8C36-4336B9F95148}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A1B95584-DF2F-4EA9-8C36-4336B9F95148}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1B95584-DF2F-4EA9-8C36-4336B9F95148}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E525689D-68FB-45AE-9F61-B4D29DA5603A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E525689D-68FB-45AE-9F61-B4D29DA5603A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E525689D-68FB-45AE-9F61-B4D29DA5603A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E525689D-68FB-45AE-9F61-B4D29DA5603A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A4E2AA03-6D35-44E0-B877-7912E0B36FB7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4E2AA03-6D35-44E0-B877-7912E0B36FB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A4E2AA03-6D35-44E0-B877-7912E0B36FB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4E2AA03-6D35-44E0-B877-7912E0B36FB7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{97ADF8B5-552A-4484-93AF-9B28BFD663F2} = {AA4021A7-A2E1-46CD-AE9C-D9D5D66C38B2}
+		{A1B95584-DF2F-4EA9-8C36-4336B9F95148} = {AA4021A7-A2E1-46CD-AE9C-D9D5D66C38B2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6BD53EE8-E3AC-4DE6-9F1F-78B0C835882E}


### PR DESCRIPTION
@denniswu-conetec - syntax updated according to what we discussed. Minimum support for format variability was added (introduce/remove property) - requires testing yet.

Note the project restructure - it makes sense to move out content related definitions to outside of the low-level IO project to make it be more stable.

Please let me know how it looks for you - feel free to merge and copy/paste if everything is OK.